### PR TITLE
Minor improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,15 @@ Erlang
 * Build desired erlang version
 
 ```
-    $ cd erlang
+    $ pushd erlang > /dev/null
     $ cat README.md             # for instructions
+    $ ./build <otp_version>     # (eg. ./build.sh 19.3)
+    $ popd
 ```
 
+tl;dr
+-----
+
+* This is the short version of these instructions, that joins all previous steps in one go:
+
+    * `git clone https://github.com/lrascao/erlang-ec2-build.git; cd erlang-ec2-build; GCC=6.3.0 OPENSSL=1.0.2l OTP=19.3 ./build.sh`

--- a/README.md
+++ b/README.md
@@ -25,13 +25,14 @@ Custom gcc
 * build a desired gcc version
 
 ```
-    $ cd gcc
+    $ pushd gcc > /dev/null
     $ cat README.md             # for instructions
     $ ./build.sh <gcc_version>  # (eg. ./build.sh 6.3.0)
+    $ popd > /dev/null
 ```
 
 * Add latest gcc to .bashrc PATH, this is the one that will be used from now on
-    * `export PATH=~/bin:~/erlang-ec2-build/gcc/releases/latest/bin:$PATH`
+    * `export PATH=~/erlang-ec2-build/gcc/releases/latest/bin:$PATH`
 
 Custom OpenSSL
 -----
@@ -39,9 +40,10 @@ Custom OpenSSL
 * Build desired openssl version
 
 ```
-    $ cd openssl
+    $ pushd openssl > /dev/null
     $ cat README.md                 # for instructions
     $ ./build.sh <openssl_version>  # (eg. ./build.sh 1.0.2l)
+    $ popd > /dev/null
 ```
 
 Erlang

--- a/build.sh
+++ b/build.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+echo "Installing git"
+sudo yum install git -y
+
+echo -e "\nInstalling development environment"
+./setup.sh
+
+echo -e "\nInstalling your choice of GCC: $GCC"
+pushd gcc > /dev/null
+./build.sh $GCC
+export PATH=~/`pwd`/releases/latest/bin:$PATH
+popd > /dev/null
+
+echo -e "\nInstalling your choice of OpenSSL: $OPENSSL"
+pushd openssl > /dev/null
+./build.sh $OPENSSL
+popd > /dev/null
+
+echo -e "\nBuilding your choice of OTP/Erlang: $OTP"
+pushd erlang > /dev/null
+./build.sh $OTP
+popd > /dev/null

--- a/erlang/build.sh
+++ b/erlang/build.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+VERSION=$1
+
+curl -O https://raw.githubusercontent.com/kerl/kerl/master/kerl
+chmod a+x kerl
+./kerl update releases
+KERL_CONFIGURE_OPTIONS="--with-ssl=/home/ec2-user/erlang-ec2-build/openssl/releases/latest --disable-dynamic-ssl-lib --enable-hipe --without-wx --without-observer --without-odbc --without-debugger --without-et --enable-builtin-zlib --without-javac --with-dynamic-trace=systemtap" CFLAGS="-g -O2 -march=native" ./kerl build $VERSION $VERSION
+
+DST=/opt/erlang
+echo "Going to install at $DST"
+sudo mkdir -p $DST
+sudo chown ec2-user:ec2-user $DST
+./kerl install $VERSION $DST/$VERSION
+
+cd $DST
+TARB=/tmp/erlang-$VERSION.tar.gz
+tar czf $TARB $VERSION
+echo "Your OTP/Erlang $VERSION tarball can be found at $TARB"

--- a/gcc/build.sh
+++ b/gcc/build.sh
@@ -30,7 +30,7 @@ pushd tarballs > /dev/null
     then
         echo "invalid signatures for gcc $VERSION"
     fi
-popd
+popd > /dev/null
 
 pushd src > /dev/null
 	cp ../tarballs/$TARBALL .
@@ -42,13 +42,13 @@ pushd src > /dev/null
 
 		make
 		make install
-	popd
-popd
+	popd > /dev/null
+popd > /dev/null
 
-pushd releases
+pushd releases > /dev/null
 	rm -f latest
 	ln -s $VERSION latest
-popd
+popd > /dev/null
 
 # update alternative gcc
 # update alternative gcc

--- a/gcc/build.sh
+++ b/gcc/build.sh
@@ -18,19 +18,12 @@ fi
 # ensure dirs
 mkdir -p src tarballs releases
 
-pushd tarballs > /dev/null
-    if [ ! -e "$TARBALL" ]
-    then
-        wget ftp://ftp.gnu.org/pub/gnu/gcc/gcc-$VERSION/$TARBALL
-        wget ftp://ftp.gnu.org/pub/gnu/gcc/gcc-$VERSION/$TARBALL.sig
-    fi
-    # verify the signature
-    gpg --verify $TARBALL.sig $TARBALL
-    if [ ! $? -eq 0 ]
-    then
-        echo "invalid signatures for gcc $VERSION"
-    fi
-popd > /dev/null
+if [ ! -e "$TARBALL" ]
+then
+    pushd tarballs > /dev/null
+    wget ftp://ftp.gnu.org/pub/gnu/gcc/gcc-$VERSION/$TARBALL
+    popd > /dev/null
+fi
 
 pushd src > /dev/null
 	cp ../tarballs/$TARBALL .

--- a/gcc/build.sh
+++ b/gcc/build.sh
@@ -3,6 +3,18 @@ VERSION=$1
 TARBALL=gcc-$VERSION.tar.gz
 BASE_DIR=`pwd`
 
+# ensure gcc and g++
+if [ "$(which gcc 2>/dev/null)" = "" ]
+then
+    echo "no valid gcc found. use update-alternatives to configure one"
+    exit 1
+fi
+if [ "$(which g++ 2>/dev/null)" = "" ]
+then
+    echo "no valid g++ found. use update-alternatives to configure one"
+    exit 1
+fi
+
 # ensure dirs
 mkdir -p src tarballs releases
 

--- a/openssl/build.sh
+++ b/openssl/build.sh
@@ -5,19 +5,12 @@ BASE_DIR=`pwd`
 
 mkdir -p releases src tarballs
 
-pushd tarballs > /dev/null
-	if [ ! -e "$TARBALL" ]
-	then
-		wget http://www.openssl.org/source/$TARBALL
-		wget http://www.openssl.org/source/$TARBALL.asc
-	fi
-	# verify the signature
-	gpg --verify $TARBALL.sig $TARBALL
-	if [ ! $? -eq 0 ]
-	then
-		echo "invalid signature for openssl-$1"
-	fi
-popd > /dev/null
+if [ ! -e "$TARBALL" ]
+then
+    pushd tarballs > /dev/null
+	wget http://www.openssl.org/source/$TARBALL
+    popd > /dev/null
+fi
 
 mkdir -p releases/$VERSION
 pushd src > /dev/null

--- a/openssl/build.sh
+++ b/openssl/build.sh
@@ -5,7 +5,7 @@ BASE_DIR=`pwd`
 
 mkdir -p releases src tarballs
 
-pushd tarballs  > /dev/null
+pushd tarballs > /dev/null
 	if [ ! -e "$TARBALL" ]
 	then
 		wget http://www.openssl.org/source/$TARBALL
@@ -17,24 +17,24 @@ pushd tarballs  > /dev/null
 	then
 		echo "invalid signature for openssl-$1"
 	fi
-popd
+popd > /dev/null
 
 mkdir -p releases/$VERSION
-pushd src
+pushd src > /dev/null
 	cp ../tarballs/$TARBALL .
 	tar xzvf $TARBALL
     rm $TARBALL
-	pushd openssl-$VERSION
+	pushd openssl-$VERSION > /dev/null
 		./config --prefix=$BASE_DIR/releases/$VERSION shared
 
 		make depend
 		make
 		make install
-	popd
-popd
+	popd > /dev/null
+popd > /dev/null
 
-pushd releases
+pushd releases > /dev/null
     rm -f latest
 	ln -s $1 latest
-popd
+popd > /dev/null
 


### PR DESCRIPTION
I followed the procedure described in `README.md`, in a recent Amazon Linux instance, and tweaked the installation steps according to the bumps I ran into along the way.

I made sure the procedure could be followed completely by copy-paste (which is why I introduced those `pushd/popd`).

I created an even shorter version of the install procedure that _does it all_ in a single step (with three env. variables only), though maintaining it as separate as the others (in its own `erlang/build.sh` file)

I added `gcc` and `g++` verifications, since not all Amazon Linux instances have this working out-of-the-box.