### PR TITLE
Prevent man-in-the-middle attack to downloaded source code

### DIFF
--- a/gcc/README.md
+++ b/gcc/README.md
@@ -1,4 +1,4 @@
-* Go to ftp://ftp.gnu.org/pub/gnu/gcc/
+* Go to https://ftp.gnu.org/pub/gnu/gcc/
 * check version you want to build (eg. 6.3.0) 
 * run ./build.sh <version> (eg. ./build.sh 6.3.0)
 

--- a/gcc/build.sh
+++ b/gcc/build.sh
@@ -21,7 +21,7 @@ mkdir -p src tarballs releases
 if [ ! -e "$TARBALL" ]
 then
     pushd tarballs > /dev/null
-    wget ftp://ftp.gnu.org/pub/gnu/gcc/gcc-$VERSION/$TARBALL
+    wget https://ftp.gnu.org/pub/gnu/gcc/gcc-$VERSION/$TARBALL
     popd > /dev/null
 fi
 

--- a/openssl/README.md
+++ b/openssl/README.md
@@ -1,4 +1,4 @@
-* Go to http://www.openssl.org/source/
+* Go to https://www.openssl.org/source/
 * check version you want to build (eg. 1.1.1b) 
 * run ./build.sh <version> (eg. ./build.sh 1.1.1b)
 

--- a/openssl/build.sh
+++ b/openssl/build.sh
@@ -8,7 +8,7 @@ mkdir -p releases src tarballs
 if [ ! -e "$TARBALL" ]
 then
     pushd tarballs > /dev/null
-	wget http://www.openssl.org/source/$TARBALL
+	wget https://www.openssl.org/source/$TARBALL
     popd > /dev/null
 fi
 


### PR DESCRIPTION
Downloading GCC and OpenSSL over cleartext channels (FTP and HTTP, respectively) exposes us to such a risk.